### PR TITLE
Add names to load parsers

### DIFF
--- a/src/adapter/loadNodeBase64.ts
+++ b/src/adapter/loadNodeBase64.ts
@@ -22,6 +22,8 @@ function isSupportedDataURL(url: string): boolean
 export const loadNodeBase64 = {
     extension: ExtensionType.LoadParser,
 
+    name: 'loadNodeBase64',
+
     test(url: string): boolean
     {
         return isSupportedDataURL(url);

--- a/src/adapter/loadNodeFont.ts
+++ b/src/adapter/loadNodeFont.ts
@@ -14,6 +14,8 @@ const validFonts = ['.woff', '.woff2', '.ttf', '.otf'];
 export const loadNodeFont = {
     extension: ExtensionType.LoadParser,
 
+    name: 'loadNodeFont',
+
     test(url: string): boolean
     {
         return validFonts.includes(utils.path.extname(url).toLowerCase());

--- a/src/adapter/loadNodeTexture.ts
+++ b/src/adapter/loadNodeTexture.ts
@@ -11,6 +11,8 @@ const validImages = ['.jpg', '.png', '.jpeg', '.svg'];
 export const loadNodeTexture = {
     extension: ExtensionType.LoadParser,
 
+    name: 'loadNodeTexture',
+
     test(url: string): boolean
     {
         return validImages.includes(utils.path.extname(url).toLowerCase());


### PR DESCRIPTION
I think this is a fair enough change? It is simple enough, so I did not open an issue but opened a pull request directly.

Sometimes I need to specify the load parser explicitly when using `Assets.load`, but it is difficult in Node.js because those extension load parsers in `@pixi/node` do not have names. This pull request fixes this problem.